### PR TITLE
feat(shared): gate subsystems via compile-time flags

### DIFF
--- a/src/shared/components/mod.zig
+++ b/src/shared/components/mod.zig
@@ -5,6 +5,13 @@
 //! - Feature-gate: check `@import("../shared/mod.zig").options.feature_widgets`
 //! - Override defaults: define `pub const shared_options = @import("../shared/mod.zig").Options{ ... };` at root.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_widgets) {
+        @compileError("components subsystem disabled; enable feature_widgets");
+    }
+}
+
 pub const progress = @import("progress.zig");
 pub const notification = @import("notification.zig");
 pub const base = @import("base.zig");

--- a/src/shared/mod.zig
+++ b/src/shared/mod.zig
@@ -20,13 +20,13 @@
 //! Feature-gate by checking `shared.options.feature_*` at comptime.
 
 pub const cli = @import("cli/mod.zig");
-pub const tui = @import("tui/mod.zig");
-pub const render = @import("render/mod.zig");
-pub const components = @import("components/mod.zig");
+pub const tui = if (options.feature_tui) @import("tui/mod.zig") else struct {};
+pub const render = if (options.feature_render) @import("render/mod.zig") else struct {};
+pub const components = if (options.feature_widgets) @import("components/mod.zig") else struct {};
 pub const tools = @import("tools/mod.zig");
 // New guardrail barrels for refactor
-pub const ui = @import("ui/mod.zig");
-pub const widgets = @import("widgets/mod.zig");
+pub const ui = if (options.feature_tui) @import("ui/mod.zig") else struct {};
+pub const widgets = if (options.feature_widgets) @import("widgets/mod.zig") else struct {};
 const build_options = @import("build_options");
 // Network barrel re-export (module, not container struct)
 pub const network = @import("network/mod.zig");
@@ -40,7 +40,7 @@ pub const Event = network.Event;
 // Backward-compat alias
 pub const NetworkClient = network.Service;
 // Align with consolidated terminal layout
-pub const term = @import("term/mod.zig");
+pub const term = if (options.feature_tui) @import("term/mod.zig") else struct {};
 
 // Unified types - consolidated data structures
 pub const types = @import("types.zig");

--- a/src/shared/network/mod.zig
+++ b/src/shared/network/mod.zig
@@ -9,15 +9,19 @@
 //! including HTTP clients, API integrations, and streaming protocols.
 
 const std = @import("std");
+const shared = @import("../mod.zig");
 
 // Core HTTP client functionality
 pub const curl = @import("curl.zig");
 
 // Anthropic API client (prefer split; legacy available behind -Dlegacy)
 const build_options = @import("build_options");
-pub const anthropic = @import("anthropic/mod.zig");
+pub const anthropic = if (shared.options.feature_network_anthropic)
+    @import("anthropic/mod.zig")
+else
+    struct {};
 /// Deprecated: legacy monolithic client. Enable with `-Dlegacy` only.
-pub const anthropic_legacy = if (build_options.include_legacy)
+pub const anthropic_legacy = if (shared.options.feature_network_anthropic and build_options.include_legacy)
     @import("legacy/mod.zig").anthropic
 else
     struct {};

--- a/src/shared/render/mod.zig
+++ b/src/shared/render/mod.zig
@@ -62,9 +62,14 @@
 //! This module will read them via `@hasDecl(root, "shared_options")`.
 //!
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_render) {
+        @compileError("render subsystem disabled; enable feature_render");
+    }
+}
 const std = @import("std");
 const root = @import("root");
-const shared = @import("../mod.zig");
 
 // -----------------------------------------------------------------------------
 // Compile-time Options for render submodule

--- a/src/shared/term/mod.zig
+++ b/src/shared/term/mod.zig
@@ -3,6 +3,13 @@
 //! Feature-gate in consumers using `@import("../mod.zig").options.feature_tui`.
 // Terminal namespace
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_tui) {
+        @compileError("terminal subsystem disabled; enable feature_tui");
+    }
+}
+
 pub const ansi = @import("ansi/mod.zig");
 pub const buffer = @import("buffer/mod.zig");
 pub const color = @import("color/mod.zig");

--- a/src/shared/testing/mod.zig
+++ b/src/shared/testing/mod.zig
@@ -4,6 +4,13 @@
 //! deep-import subfiles. Tests may gate TUI-dependent helpers behind
 //! `@import("../shared/mod.zig").options.feature_tui`.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_tui) {
+        @compileError("testing subsystem requires feature_tui");
+    }
+}
+
 pub const snapshot = @import("snapshot.zig");
 
 // Re-export main types for convenience

--- a/src/shared/tools/mod.zig
+++ b/src/shared/tools/mod.zig
@@ -6,6 +6,13 @@
 //! - Override behavior (e.g., enable/disable builtins) by defining
 //!   `pub const shared_options = @import("../shared/mod.zig").Options{ ... };` at root.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_widgets) {
+        @compileError("tools subsystem disabled; enable feature_widgets");
+    }
+}
+
 pub const Registry = @import("tools.zig").Registry;
 pub const registerBuiltins = @import("tools.zig").registerBuiltins;
 pub const ToolError = @import("tools.zig").ToolError;

--- a/src/shared/tui/mod.zig
+++ b/src/shared/tui/mod.zig
@@ -6,6 +6,12 @@
 //! - Feature-gate: `comptime if (@import("../shared/mod.zig").options.feature_tui) { ... }`
 //! - Override behavior: define `pub const shared_options = @import("../shared/mod.zig").Options{ ... };` in the root module.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_tui) {
+        @compileError("TUI subsystem disabled; enable feature_tui");
+    }
+}
 const std = @import("std");
 const term_shared = @import("term_shared");
 

--- a/src/shared/ui/mod.zig
+++ b/src/shared/ui/mod.zig
@@ -4,6 +4,13 @@
 //! Import via this barrel. If you need to feature-gate, use
 //! `@import("../shared/mod.zig").options.feature_tui` in consumers.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_tui) {
+        @compileError("ui subsystem disabled; enable feature_tui");
+    }
+}
+
 pub const component = @import("component/mod.zig");
 pub const layout = @import("layout/mod.zig");
 pub const event = @import("event/mod.zig");

--- a/src/shared/widgets/mod.zig
+++ b/src/shared/widgets/mod.zig
@@ -2,6 +2,13 @@
 //! Exposes widget families via sub-barrels; avoid importing individual files.
 //! Feature-gate at call sites via `@import("../shared/mod.zig").options.feature_widgets`.
 
+const shared = @import("../mod.zig");
+comptime {
+    if (!shared.options.feature_widgets) {
+        @compileError("widgets subsystem disabled; enable feature_widgets");
+    }
+}
+
 pub const chart = @import("chart/mod.zig");
 pub const table = @import("table/mod.zig");
 pub const progress = @import("progress/mod.zig");


### PR DESCRIPTION
## Summary
- conditionally import shared subsystems based on feature flags
- guard subsystem barrels with compile-time checks for disabled features
- wrap Anthropics client behind feature flag in network module

## Testing
- `zig fmt src/shared/mod.zig src/shared/term/mod.zig src/shared/tui/mod.zig src/shared/render/mod.zig src/shared/components/mod.zig src/shared/widgets/mod.zig src/shared/ui/mod.zig src/shared/network/mod.zig src/shared/tools/mod.zig src/shared/testing/mod.zig`
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_68b32ee1fa7883298db52fd086e8a221