### PR TITLE
refactor: encapsulate JSON reflection

### DIFF
--- a/agents/markdown/tools/io.zig
+++ b/agents/markdown/tools/io.zig
@@ -12,7 +12,7 @@
 //! - Compile-time guarantees that required fields are present
 //!
 //! ### 2. Automatic JSON Serialization
-//! - Uses `json_reflection.generateJsonMapper()` for automatic field mapping
+//! - Uses `JsonReflector.mapper()` for automatic field mapping
 //! - Automatic conversion between PascalCase structs and snake_case JSON
 //! - No more manual `put()` calls or field extraction errors
 //!
@@ -61,7 +61,7 @@
 
 const std = @import("std");
 const json = std.json;
-const json_reflection = @import("../../../src/shared/json_reflection/mod.zig");
+const JsonReflector = @import("json_reflection").JsonReflector;
 const fs = @import("../lib/fs.zig");
 const text = @import("../lib/text.zig");
 const link = @import("../lib/link.zig");
@@ -361,7 +361,7 @@ pub fn execute(allocator: std.mem.Allocator, params: json.Value) !json.Value {
             .error_message = @errorName(err),
         };
 
-        const Mapper = json_reflection.generateJsonMapper(BaseResponse);
+        const Mapper = JsonReflector.mapper(BaseResponse);
         return Mapper.toJsonValue(allocator, error_response);
     };
 }
@@ -394,7 +394,7 @@ fn executeInternal(allocator: std.mem.Allocator, params: json.Value) !json.Value
 /// - Clear separation of concerns
 fn readFile(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection - eliminates manual field extraction
-    const RequestMapper = json_reflection.generateJsonMapper(ReadFileRequest);
+    const RequestMapper = JsonReflector.mapper(ReadFileRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -421,7 +421,7 @@ fn readFile(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     }
 
     // Serialize response using json_reflection - automatic field mapping
-    const ResponseMapper = json_reflection.generateJsonMapper(ReadFileResponse);
+    const ResponseMapper = JsonReflector.mapper(ReadFileResponse);
     return ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -434,7 +434,7 @@ fn readFile(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Better error handling for missing files
 fn readMultiple(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(ReadMultipleRequest);
+    const RequestMapper = JsonReflector.mapper(ReadMultipleRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -489,7 +489,7 @@ fn readMultiple(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(ReadMultipleResponse);
+    const ResponseMapper = JsonReflector.mapper(ReadMultipleResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -502,7 +502,7 @@ fn readMultiple(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Better error handling for invalid section identifiers
 fn readSection(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(ReadSectionRequest);
+    const RequestMapper = JsonReflector.mapper(ReadSectionRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -535,7 +535,7 @@ fn readSection(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(ReadSectionResponse);
+    const ResponseMapper = JsonReflector.mapper(ReadSectionResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -548,7 +548,7 @@ fn readSection(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - More maintainable code structure
 fn searchContent(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(SearchContentRequest);
+    const RequestMapper = JsonReflector.mapper(SearchContentRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -628,7 +628,7 @@ fn searchContent(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(SearchContentResponse);
+    const ResponseMapper = JsonReflector.mapper(SearchContentResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -640,7 +640,7 @@ fn searchContent(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Consistent error handling
 fn searchPattern(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse original request
-    const RequestMapper = json_reflection.generateJsonMapper(SearchContentRequest);
+    const RequestMapper = JsonReflector.mapper(SearchContentRequest);
     const original_request = try RequestMapper.fromJson(allocator, params);
     defer original_request.deinit();
 
@@ -659,7 +659,7 @@ fn searchPattern(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize modified request and delegate to searchContent
-    const ModifiedMapper = json_reflection.generateJsonMapper(SearchContentRequest);
+    const ModifiedMapper = JsonReflector.mapper(SearchContentRequest);
     const modified_params = try ModifiedMapper.toJsonValue(allocator, modified_request);
     defer modified_params.deinit();
 
@@ -675,7 +675,7 @@ fn searchPattern(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Better memory management for results
 fn findReferences(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(FindReferencesRequest);
+    const RequestMapper = JsonReflector.mapper(FindReferencesRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -732,7 +732,7 @@ fn findReferences(allocator: std.mem.Allocator, params: json.Value) !json.Value 
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(FindReferencesResponse);
+    const ResponseMapper = JsonReflector.mapper(FindReferencesResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -745,7 +745,7 @@ fn findReferences(allocator: std.mem.Allocator, params: json.Value) !json.Value 
 /// - Better error handling for inaccessible files
 fn listDirectory(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(ListDirectoryRequest);
+    const RequestMapper = JsonReflector.mapper(ListDirectoryRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -806,7 +806,7 @@ fn listDirectory(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(ListDirectoryResponse);
+    const ResponseMapper = JsonReflector.mapper(ListDirectoryResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -819,7 +819,7 @@ fn listDirectory(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Better memory management
 fn findFiles(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(FindFilesRequest);
+    const RequestMapper = JsonReflector.mapper(FindFilesRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -852,7 +852,7 @@ fn findFiles(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(FindFilesResponse);
+    const ResponseMapper = JsonReflector.mapper(FindFilesResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 
@@ -865,7 +865,7 @@ fn findFiles(allocator: std.mem.Allocator, params: json.Value) !json.Value {
 /// - Consistent response structure
 fn getWorkspaceTree(allocator: std.mem.Allocator, params: json.Value) !json.Value {
     // Parse request using json_reflection
-    const RequestMapper = json_reflection.generateJsonMapper(GetWorkspaceTreeRequest);
+    const RequestMapper = JsonReflector.mapper(GetWorkspaceTreeRequest);
     const request = try RequestMapper.fromJson(allocator, params);
     defer request.deinit();
 
@@ -880,7 +880,7 @@ fn getWorkspaceTree(allocator: std.mem.Allocator, params: json.Value) !json.Valu
     };
 
     // Serialize response using json_reflection
-    const ResponseMapper = json_reflection.generateJsonMapper(GetWorkspaceTreeResponse);
+    const ResponseMapper = JsonReflector.mapper(GetWorkspaceTreeResponse);
     return try ResponseMapper.toJsonValue(allocator, response);
 }
 

--- a/agents/test_agent/tools/Tool.zig
+++ b/agents/test_agent/tools/Tool.zig
@@ -77,7 +77,7 @@
 //! const message = params.object.get("message").?.string;
 //!
 //! // NEW: Automatic deserialization
-//! const RequestMapper = json_reflection.generateJsonMapper(Request);
+//! const RequestMapper = JsonReflector.mapper(Request);
 //! const parsed = try RequestMapper.fromJson(allocator, params);
 //! defer parsed.deinit();
 //! const request = parsed.value;
@@ -96,7 +96,7 @@
 //!     .success = true,
 //!     .metadata = .{ .processed_at = std.time.timestamp() },
 //! };
-//! const ResponseMapper = json_reflection.generateJsonMapper(Response);
+//! const ResponseMapper = JsonReflector.mapper(Response);
 //! return ResponseMapper.toJsonValue(allocator, response);
 //! ```
 //!
@@ -232,7 +232,7 @@
 
 const std = @import("std");
 const toolsMod = @import("tools_shared");
-const json_reflection = @import("json_reflection");
+const JsonReflector = @import("json_reflection").JsonReflector;
 
 /// Request structure for the example tool.
 /// This replaces manual parameter extraction and provides compile-time type safety.
@@ -302,7 +302,7 @@ pub fn execute(allocator: std.mem.Allocator, params: std.json.Value) toolsMod.To
     // ============================================================================
 
     // Generate JSON mapper for our Request struct at compile time
-    const RequestMapper = json_reflection.generateJsonMapper(Request);
+    const RequestMapper = JsonReflector.mapper(Request);
 
     // Deserialize JSON to struct - this replaces all manual field extraction
     const parsed = RequestMapper.fromJson(allocator, params) catch
@@ -382,7 +382,7 @@ pub fn execute(allocator: std.mem.Allocator, params: std.json.Value) toolsMod.To
     };
 
     // Generate JSON mapper for our Response struct at compile time
-    const ResponseMapper = json_reflection.generateJsonMapper(Response);
+    const ResponseMapper = JsonReflector.mapper(Response);
 
     // Serialize struct to JSON value - this replaces manual ObjectMap building
     const json_response = ResponseMapper.toJsonValue(allocator, response) catch
@@ -473,7 +473,7 @@ pub fn complexExecute(allocator: std.mem.Allocator, params: std.json.Value) tool
     // COMPLEX DESERIALIZATION
     // ============================================================================
 
-    const ComplexMapper = json_reflection.generateJsonMapper(ComplexRequest);
+    const ComplexMapper = JsonReflector.mapper(ComplexRequest);
     const parsed = ComplexMapper.fromJson(allocator, params) catch
         return toolsMod.ToolError.MalformedJSON;
     defer parsed.deinit();
@@ -581,7 +581,7 @@ pub fn complexExecute(allocator: std.mem.Allocator, params: std.json.Value) tool
     // COMPLEX SERIALIZATION
     // ============================================================================
 
-    const ResponseMapper = json_reflection.generateJsonMapper(ComplexResponse);
+    const ResponseMapper = JsonReflector.mapper(ComplexResponse);
     const json_response = ResponseMapper.toJsonValue(allocator, complex_response) catch
         return toolsMod.ToolError.ExecutionFailed;
 

--- a/agents/test_agent/tools/mod.zig
+++ b/agents/test_agent/tools/mod.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const toolsMod = @import("tools_shared");
+const JsonReflector = @import("json_reflection").JsonReflector;
 
 // Tool Implementation
 pub const Tool = @import("Tool.zig");
@@ -29,8 +30,7 @@ pub fn testTool(allocator: std.mem.Allocator, params: std.json.Value) toolsMod.T
     };
 
     // Generate JSON mapper and serialize
-    const json_reflection = @import("json_reflection");
-    const ResponseMapper = json_reflection.generateJsonMapper(TestResponse);
+    const ResponseMapper = JsonReflector.mapper(TestResponse);
     return ResponseMapper.toJsonValue(allocator, response);
 }
 

--- a/docs/JSON_REFLECTION_PATTERNS.md
+++ b/docs/JSON_REFLECTION_PATTERNS.md
@@ -64,10 +64,10 @@ pub fn createUserResponseOld(allocator: std.mem.Allocator, user: User) ![]const 
 ### 2. Use Reflection-Based Serialization
 
 ```zig
-const json_reflection = @import("../shared/json_reflection.zig");
+const JsonReflector = @import("../shared/json_reflection/mod.zig").JsonReflector;
 
 // Generate mapper for your struct
-const UserMapper = json_reflection.generateJsonMapper(UserProfile);
+const UserMapper = JsonReflector.mapper(UserProfile);
 
 // Serialize struct to JSON
 pub fn serializeUser(allocator: std.mem.Allocator, user: UserProfile) ![]const u8 {
@@ -275,7 +275,7 @@ pub const UserResponse = struct {
 };
 
 // 2. Generate mapper (once, at module level)
-const UserMapper = json_reflection.generateJsonMapper(UserResponse);
+const UserMapper = JsonReflector.mapper(UserResponse);
 
 // 3. Use for serialization (simple)
 pub fn createUserResponseNew(allocator: std.mem.Allocator, user: User) ![]const u8 {
@@ -381,7 +381,7 @@ pub fn handleFileOperation(allocator: std.mem.Allocator, request: json_schemas.F
 
 ```zig
 pub fn safeJsonOperation(allocator: std.mem.Allocator, json_str: []const u8) !UserProfile {
-    return json_reflection.generateJsonMapper(UserProfile).fromJson(allocator, json_str) catch |err| {
+    return JsonReflector.mapper(UserProfile).fromJson(allocator, json_str) catch |err| {
         return switch (err) {
             error.MalformedJson => tools_mod.ToolError.MalformedJSON,
             error.InvalidFieldType => tools_mod.ToolError.InvalidInput,
@@ -412,8 +412,8 @@ pub const APIClient = struct {
         error_message: ?[]const u8,
     };
 
-    const LoginMapper = json_reflection.generateJsonMapper(LoginRequest);
-    const ResponseMapper = json_reflection.generateJsonMapper(LoginResponse);
+    const LoginMapper = JsonReflector.mapper(LoginRequest);
+    const ResponseMapper = JsonReflector.mapper(LoginResponse);
 
     pub fn login(self: *APIClient, request: LoginRequest) !LoginResponse {
         // Serialize request
@@ -451,7 +451,7 @@ pub const AppConfig = struct {
     },
 };
 
-const ConfigMapper = json_reflection.generateJsonMapper(AppConfig);
+const ConfigMapper = JsonReflector.mapper(AppConfig);
 
 pub fn loadConfig(allocator: std.mem.Allocator, config_path: []const u8) !AppConfig {
     const config_content = try std.fs.cwd().readFileAlloc(allocator, config_path, 1 << 20);
@@ -489,8 +489,8 @@ pub const ProcessingPipeline = struct {
         processing_time_ms: u64 = 0,
     };
 
-    const DocMapper = json_reflection.generateJsonMapper(Document);
-    const StepMapper = json_reflection.generateJsonMapper(ProcessingStep);
+    const DocMapper = JsonReflector.mapper(Document);
+    const StepMapper = JsonReflector.mapper(ProcessingStep);
 
     pub fn processDocument(self: *ProcessingPipeline, doc_json: []const u8) ![]const u8 {
         // Parse input document
@@ -565,8 +565,8 @@ pub const EventLogger = struct {
         source_system: []const u8,
     };
 
-    const EventMapper = json_reflection.generateJsonMapper(LogEvent);
-    const BatchMapper = json_reflection.generateJsonMapper(LogBatch);
+    const EventMapper = JsonReflector.mapper(LogEvent);
+    const BatchMapper = JsonReflector.mapper(LogBatch);
 
     pub fn logEvent(self: *EventLogger, event: LogEvent) !void {
         const event_json = try EventMapper.toJson(self.allocator, event, .{});

--- a/src/shared/json_reflection/mod.zig
+++ b/src/shared/json_reflection/mod.zig
@@ -1,8 +1,4 @@
 //! JSON reflection utilities barrel.
 //! Import via this barrel; do not deep-import subfiles.
 
-pub const json_reflection = @import("json_reflection.zig");
-pub const generateJsonMapper = json_reflection.generateJsonMapper;
-pub const generateJsonDeserializer = json_reflection.generateJsonDeserializer;
-pub const generateJsonSerializer = json_reflection.generateJsonSerializer;
-pub const fieldNameToJson = json_reflection.fieldNameToJson;
+pub const JsonReflector = @import("json_reflection.zig").JsonReflector;


### PR DESCRIPTION
## Summary
- wrap JSON reflection helpers in `JsonReflector` struct with Self-based methods for field mapping and serialization
- expose `JsonReflector` from the module barrel and update agents to use the new API
- update documentation and examples for struct-based reflection usage

## Testing
- `zig build list-agents`
- `zig build validate-agents`
- `zig build -Dagent=test_agent test`
- `zig build -Dagent=markdown test`
- `zig build fmt`
- `zig test src/shared/json_reflection/json_reflection.zig`


------
https://chatgpt.com/codex/tasks/task_e_68b39303ee288329b26708d4634843bd