### PR TITLE
feat: add component error type

### DIFF
--- a/src/shared/components/mod.zig
+++ b/src/shared/components/mod.zig
@@ -73,6 +73,7 @@ pub const Event = base.Event;
 pub const Theme = base.Theme;
 pub const Animation = base.Animation;
 pub const Render = base.Render;
+pub const ComponentError = base.ComponentError;
 
 // Note: Additional UI context helpers are available under legacy shims
 // when building with -Dlegacy.


### PR DESCRIPTION
## Summary
- add `ComponentError` to cover lifecycle, rendering, event issues
- switch component vtables and registry to use `ComponentError`
- propagate `ComponentError` through UI helpers and input/progress components

## Testing
- `zig fmt src/shared/components/base.zig src/shared/components/progress.zig src/shared/components/input.zig src/shared/components/ui.zig src/shared/components/mod.zig`
- `zig build fmt`
- `zig build list-agents`
- `zig build validate-agents`
- `zig build -Dagent=markdown test`
- `zig build -Dagent=test_agent test`


------
https://chatgpt.com/codex/tasks/task_e_68b3930c57b083298d40e62fac20d6a3