### PR TITLE
Add typed WorkflowError to CLI workflows

### DIFF
--- a/src/shared/cli/commands/auth.zig
+++ b/src/shared/cli/commands/auth.zig
@@ -403,7 +403,7 @@ pub const AuthCommands = struct {
 
 // Workflow step implementations
 
-fn generateAuthURL(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn generateAuthURL(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 
@@ -412,7 +412,7 @@ fn generateAuthURL(allocator: Allocator, context: ?workflow_step.StepContext) an
     return .{ .success = true, .outputData = "https://api.anthropic.com/oauth/authorize?client_id=demo&response_type=code" };
 }
 
-fn openBrowser(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn openBrowser(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 
@@ -421,7 +421,7 @@ fn openBrowser(allocator: Allocator, context: ?workflow_step.StepContext) anyerr
     return .{ .success = true };
 }
 
-fn waitForCallback(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn waitForCallback(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 
@@ -430,7 +430,7 @@ fn waitForCallback(allocator: Allocator, context: ?workflow_step.StepContext) an
     return .{ .success = true, .outputData = "authorization_code_12345" };
 }
 
-fn exchangeCodeForToken(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn exchangeCodeForToken(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 
@@ -439,7 +439,7 @@ fn exchangeCodeForToken(allocator: Allocator, context: ?workflow_step.StepContex
     return .{ .success = true, .outputData = "access_token_abc123" };
 }
 
-fn validateToken(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn validateToken(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 
@@ -448,7 +448,7 @@ fn validateToken(allocator: Allocator, context: ?workflow_step.StepContext) anye
     return .{ .success = true };
 }
 
-fn saveCredentials(allocator: Allocator, context: ?workflow_step.StepContext) anyerror!workflow_step.WorkflowStepResult {
+fn saveCredentials(allocator: Allocator, context: ?workflow_step.StepContext) workflow_step.WorkflowError!workflow_step.WorkflowStepResult {
     _ = allocator;
     _ = context;
 

--- a/src/shared/cli/workflows/workflow_registry.zig
+++ b/src/shared/cli/workflows/workflow_registry.zig
@@ -195,7 +195,7 @@ pub const WorkflowRegistry = struct {
 
 fn createAuthVerificationStep() WorkflowStep.WorkflowStep {
     const AuthVerifyImpl = struct {
-        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) anyerror!WorkflowStep.WorkflowStepResult {
+        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) WorkflowStep.WorkflowError!WorkflowStep.WorkflowStepResult {
             _ = allocator;
             _ = ctx;
 
@@ -213,7 +213,7 @@ fn createAuthVerificationStep() WorkflowStep.WorkflowStep {
 
 fn createConfigOptimizationStep() WorkflowStep.WorkflowStep {
     const ConfigOptimizeImpl = struct {
-        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) anyerror!WorkflowStep.WorkflowStepResult {
+        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) WorkflowStep.WorkflowError!WorkflowStep.WorkflowStepResult {
             _ = allocator;
             _ = ctx;
 
@@ -230,7 +230,7 @@ fn createConfigOptimizationStep() WorkflowStep.WorkflowStep {
 
 fn createInitialConfigStep() WorkflowStep.WorkflowStep {
     const InitConfigImpl = struct {
-        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) anyerror!WorkflowStep.WorkflowStepResult {
+        fn execute(allocator: std.mem.Allocator, ctx: ?WorkflowStep.StepContext) WorkflowStep.WorkflowError!WorkflowStep.WorkflowStepResult {
             _ = ctx;
 
             // Create configuration if it doesn't exist


### PR DESCRIPTION
## Summary
- add `WorkflowError` to describe IO, validation and timeout failures
- update workflow steps, builders and registry to use typed errors
- adjust auth workflow step implementations to propagate `WorkflowError`

## Testing
- `zig fmt src/shared/cli/workflows/workflow_step.zig src/shared/cli/workflows/workflow_registry.zig src/shared/cli/commands/auth.zig`
- `zig build fmt`
- `zig build list-agents`
- `zig build validate-agents`
- `zig build -Dagent=test_agent test`
- `zig build -Dagent=markdown test`


------
https://chatgpt.com/codex/tasks/task_e_68b39321097c8329b24ab12a49d1160f