### PR TITLE
Add injectable logger for widgets and theme runtime

### DIFF
--- a/src/shared/logger.zig
+++ b/src/shared/logger.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+
+/// Logger interface: function pointer accepting format string and arguments
+pub const Logger = *const fn ([]const u8, anytype) void;
+
+/// Default logger that wraps std.debug.print
+pub fn defaultLogger(fmt: []const u8, args: anytype) void {
+    std.debug.print(fmt, args);
+}

--- a/src/shared/theme/mod.zig
+++ b/src/shared/theme/mod.zig
@@ -40,7 +40,8 @@ pub const options: Options = blk: {
 };
 
 // Runtime exports - always available
-pub const Theme = @import("runtime/Theme.zig").Theme;
+pub const Theme = @import("runtime/theme.zig").Theme;
+pub const Logger = @import("runtime/theme.zig").Logger;
 pub const Settings = @import("runtime/config.zig").Settings;
 pub const ColorScheme = @import("runtime/ColorScheme.zig").ColorScheme;
 pub const Color = @import("runtime/Color.zig").Color;
@@ -59,8 +60,8 @@ pub const Development = @import("tools/Development.zig").Development;
 pub const Generator = @import("tools/Generator.zig").Generator;
 
 /// Initialize the global theme manager
-pub fn init(allocator: std.mem.Allocator) !*Theme {
-    return Theme.init(allocator);
+pub fn init(allocator: std.mem.Allocator, logger: ?Logger) !*Theme {
+    return Theme.init(allocator, logger);
 }
 
 /// Quick access to common theme operations
@@ -92,7 +93,7 @@ pub const Quick = struct {
 
 test "theme manager initialization" {
     const allocator = std.testing.allocator;
-    const manager = try init(allocator);
+    const manager = try init(allocator, null);
     defer manager.deinit();
 
     try std.testing.expect(manager.themes.count() > 0);

--- a/src/shared/theme/runtime/ThemeManager.zig
+++ b/src/shared/theme/runtime/ThemeManager.zig
@@ -8,6 +8,13 @@ const Settings = @import("config.zig").Settings;
 const Inheritance = @import("Inheritance.zig").Inheritance;
 const SystemTheme = @import("Theme.zig").Theme;
 const Validator = @import("Validator.zig").Validator;
+const logging = @import("src/shared/logger.zig");
+
+pub const Logger = logging.Logger;
+
+fn defaultLogger(fmt: []const u8, args: anytype) void {
+    logging.defaultLogger(fmt, args);
+}
 
 pub const Theme = struct {
     allocator: std.mem.Allocator,
@@ -19,6 +26,7 @@ pub const Theme = struct {
     validator: *Validator,
     configPath: []const u8,
     autoSave: bool,
+    logger: Logger,
 
     // Event callbacks
     onThemeChange: ?*const fn (*ColorScheme) void,
@@ -27,7 +35,7 @@ pub const Theme = struct {
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator) !*Self {
+    pub fn init(allocator: std.mem.Allocator, logFn: ?Logger) !*Self {
         const self = try allocator.create(Self);
         self.* = .{
             .allocator = allocator,
@@ -39,6 +47,7 @@ pub const Theme = struct {
             .validator = try Validator.init(allocator),
             .configPath = try getDefaultConfigPath(allocator),
             .autoSave = true,
+            .logger = logFn orelse defaultLogger,
             .onThemeChange = null,
             .onThemeLoaded = null,
             .onThemeError = null,
@@ -62,7 +71,7 @@ pub const Theme = struct {
         // Save config if auto-save is enabled
         if (self.autoSave) {
             self.saveConfig() catch |err| {
-                std.debug.print("Failed to save theme config: {}\n", .{err});
+                self.logger("Failed to save theme config: {}\n", .{err});
             };
         }
 
@@ -139,7 +148,7 @@ pub const Theme = struct {
             defer self.allocator.free(themePath);
 
             const theme = self.loadThemeFromFile(themePath) catch |err| {
-                std.debug.print("Failed to load theme {s}: {}\n", .{ entry.name, err });
+                self.logger("Failed to load theme {s}: {}\n", .{ entry.name, err });
                 continue;
             };
 

--- a/src/shared/theme/tools/development.zig
+++ b/src/shared/theme/tools/development.zig
@@ -160,7 +160,7 @@ pub const Development = struct {
         try writer.writeAll("## Usage\n\n");
         try writer.writeAll("```zig\n");
         try writer.writeAll("// In your application\n");
-        try writer.print("const theme = try Theme.init(allocator);\n", .{});
+        try writer.print("const theme = try Theme.init(allocator, null);\n", .{});
         try writer.print("try theme.switchTheme(\"{s}\");\n", .{theme.name});
         try writer.writeAll("```\n");
 

--- a/src/shared/tui/widgets/dashboard/bar_chart.zig
+++ b/src/shared/tui/widgets/dashboard/bar_chart.zig
@@ -2,15 +2,18 @@
 
 const std = @import("std");
 const engine_mod = @import("engine.zig");
+const logging = @import("src/shared/logger.zig");
 
 pub const BarChart = struct {
     allocator: std.mem.Allocator,
+    logger: logging.Logger,
 
-    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier) !*BarChart {
+    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier, logFn: ?logging.Logger) !*BarChart {
         _ = capability_tier;
         const chart = try allocator.create(BarChart);
         chart.* = .{
             .allocator = allocator,
+            .logger = logFn orelse logging.defaultLogger,
         };
         return chart;
     }
@@ -23,7 +26,7 @@ pub const BarChart = struct {
         _ = self;
         _ = render_pipeline;
         _ = bounds;
-        std.debug.print("📊 Bar Chart Widget\n", .{});
+        self.logger("📊 Bar Chart Widget\n", .{});
     }
 
     pub fn handleInput(self: *BarChart, input: anytype) !bool {

--- a/src/shared/tui/widgets/dashboard/grid.zig
+++ b/src/shared/tui/widgets/dashboard/grid.zig
@@ -2,15 +2,18 @@
 
 const std = @import("std");
 const engine_mod = @import("engine.zig");
+const logging = @import("src/shared/logger.zig");
 
 pub const Grid = struct {
     allocator: std.mem.Allocator,
+    logger: logging.Logger,
 
-    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier) !*Grid {
+    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier, logFn: ?logging.Logger) !*Grid {
         _ = capability_tier;
         const grid = try allocator.create(Grid);
         grid.* = .{
             .allocator = allocator,
+            .logger = logFn orelse logging.defaultLogger,
         };
         return grid;
     }
@@ -23,7 +26,7 @@ pub const Grid = struct {
         _ = self;
         _ = render_pipeline;
         _ = bounds;
-        std.debug.print("📋 Grid Widget\n", .{});
+        self.logger("📋 Grid Widget\n", .{});
     }
 
     pub fn handleInput(self: *Grid, input: anytype) !bool {

--- a/src/shared/tui/widgets/dashboard/heatmap.zig
+++ b/src/shared/tui/widgets/dashboard/heatmap.zig
@@ -2,15 +2,18 @@
 
 const std = @import("std");
 const engine_mod = @import("engine.zig");
+const logging = @import("src/shared/logger.zig");
 
 pub const Heatmap = struct {
     allocator: std.mem.Allocator,
+    logger: logging.Logger,
 
-    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier) !*Heatmap {
+    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier, logFn: ?logging.Logger) !*Heatmap {
         _ = capability_tier;
         const heatmap = try allocator.create(Heatmap);
         heatmap.* = .{
             .allocator = allocator,
+            .logger = logFn orelse logging.defaultLogger,
         };
         return heatmap;
     }
@@ -23,7 +26,7 @@ pub const Heatmap = struct {
         _ = self;
         _ = render_pipeline;
         _ = bounds;
-        std.debug.print("🔥 Heatmap Widget\n", .{});
+        self.logger("🔥 Heatmap Widget\n", .{});
     }
 
     pub fn handleInput(self: *Heatmap, input: anytype) !bool {

--- a/src/shared/tui/widgets/dashboard/kpi_card.zig
+++ b/src/shared/tui/widgets/dashboard/kpi_card.zig
@@ -2,15 +2,18 @@
 
 const std = @import("std");
 const engine_mod = @import("engine.zig");
+const logging = @import("src/shared/logger.zig");
 
 pub const KPICard = struct {
     allocator: std.mem.Allocator,
+    logger: logging.Logger,
 
-    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier) !*KPICard {
+    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier, logFn: ?logging.Logger) !*KPICard {
         _ = capability_tier;
         const card = try allocator.create(KPICard);
         card.* = .{
             .allocator = allocator,
+            .logger = logFn orelse logging.defaultLogger,
         };
         return card;
     }
@@ -23,7 +26,7 @@ pub const KPICard = struct {
         _ = self;
         _ = render_pipeline;
         _ = bounds;
-        std.debug.print("💳 KPI Card Widget\n", .{});
+        self.logger("💳 KPI Card Widget\n", .{});
     }
 
     pub fn handleInput(self: *KPICard, input: anytype) !bool {

--- a/src/shared/tui/widgets/dashboard/line_chart.zig
+++ b/src/shared/tui/widgets/dashboard/line_chart.zig
@@ -8,6 +8,7 @@
 
 const std = @import("std");
 const engine_mod = @import("engine.zig");
+const logging = @import("src/shared/logger.zig");
 const term_caps = @import("../../term/capabilities.zig");
 const graphics_manager = @import("../../term/graphics_manager.zig");
 const term_shared = @import("../../../../term_shared.zig");
@@ -25,6 +26,7 @@ pub const LineChart = struct {
     axes: AxesConfig,
     interaction: InteractionState,
     animation: AnimationState,
+    logger: logging.Logger,
 
     pub const Point = struct {
         x: f64,
@@ -167,7 +169,7 @@ pub const LineChart = struct {
         height: u32,
     };
 
-    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier) !*LineChart {
+    pub fn init(allocator: std.mem.Allocator, capability_tier: engine_mod.DashboardEngine.CapabilityTier, logFn: ?logging.Logger) !*LineChart {
         const chart = try allocator.create(LineChart);
 
         chart.* = .{
@@ -184,6 +186,7 @@ pub const LineChart = struct {
             .axes = .{},
             .interaction = .{},
             .animation = .{},
+            .logger = logFn orelse logging.defaultLogger,
         };
 
         return chart;
@@ -330,7 +333,7 @@ pub const LineChart = struct {
         // 4. Encode as Kitty graphics protocol image
         // 5. Output to terminal
 
-        std.debug.print("[Kitty WebGL Line Chart - {d} series]\n", .{self.series.items.len});
+        self.logger("[Kitty WebGL Line Chart - {d} series]\n", .{self.series.items.len});
     }
 
     fn renderSixelOptimized(self: *LineChart, bounds: Bounds) !void {

--- a/src/shared/tui/widgets/mod.zig
+++ b/src/shared/tui/widgets/mod.zig
@@ -4,6 +4,15 @@
 
 const std = @import("std");
 const SharedContext = @import("context_shared").SharedContext;
+const logging = @import("src/shared/logger.zig");
+
+pub const Logger = logging.Logger;
+
+var logger: Logger = logging.defaultLogger;
+
+pub fn setLogger(l: Logger) void {
+    logger = l;
+}
 
 // Core widgets (essential functionality)
 pub const core = @import("core/mod.zig");
@@ -121,30 +130,30 @@ pub fn deinitNotifications(ctx: *SharedContext) void {
 
 pub fn notifyInfo(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("ℹ️  {s}\n", .{message});
+    logger("ℹ️  {s}\n", .{message});
 }
 
 pub fn notifySuccess(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("✅ {s}\n", .{message});
+    logger("✅ {s}\n", .{message});
 }
 
 pub fn notifyWarning(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("⚠️  {s}\n", .{message});
+    logger("⚠️  {s}\n", .{message});
 }
 
 pub fn notifyError(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("❌ {s}\n", .{message});
+    logger("❌ {s}\n", .{message});
 }
 
 pub fn notifyDebug(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("🐛 {s}\n", .{message});
+    logger("🐛 {s}\n", .{message});
 }
 
 pub fn notifyCritical(ctx: *SharedContext, message: []const u8) void {
     _ = ctx;
-    std.debug.print("🚨 {s}\n", .{message});
+    logger("🚨 {s}\n", .{message});
 }


### PR DESCRIPTION
## Summary
- add shared `Logger` interface with default `std.debug.print` wrapper
- inject logger into TUI widgets, dashboard components, and theme runtime
- expose optional logger through theme API and fix test usage

## Testing
- `zig fmt src/shared/logger.zig src/shared/tui/widgets/mod.zig src/shared/theme/runtime/theme.zig src/shared/theme/runtime/ThemeManager.zig src/shared/theme/mod.zig src/shared/theme/tools/development.zig src/shared/tui/widgets/dashboard/bar_chart.zig src/shared/tui/widgets/dashboard/gauge.zig src/shared/tui/widgets/dashboard/grid.zig src/shared/tui/widgets/dashboard/heatmap.zig src/shared/tui/widgets/dashboard/kpi_card.zig src/shared/tui/widgets/dashboard/line_chart.zig`
- `zig fmt src/shared/tui/widgets/mod.zig src/shared/theme/runtime/theme.zig src/shared/theme/runtime/ThemeManager.zig src/shared/theme/mod.zig src/shared/theme/tools/development.zig src/shared/tui/widgets/dashboard/bar_chart.zig src/shared/tui/widgets/dashboard/gauge.zig src/shared/tui/widgets/dashboard/grid.zig src/shared/tui/widgets/dashboard/heatmap.zig src/shared/tui/widgets/dashboard/kpi_card.zig src/shared/tui/widgets/dashboard/line_chart.zig`
- `zig build fmt`
- `zig build test`
- `zig build list-agents`
- `zig build validate-agents`
- `zig build -Dagent=test_agent test`
- `zig build -Dagent=markdown test`
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_68b3932f10c88329bdde39a3b5f19502